### PR TITLE
Update timestamp on already-stripped files

### DIFF
--- a/nudebomb/mkv.py
+++ b/nudebomb/mkv.py
@@ -228,7 +228,15 @@ class MKVFile:
         return output, command, relabeled
 
     def remove_tracks(self) -> bool:
-        """Remove the unwanted tracks."""
+        """
+        Remove the unwanted tracks.
+
+        Returns True if the file is in the desired state — remuxed this
+        run OR already-stripped before. Walk uses this to decide whether
+        to write a timestamp; both states mean "no need to re-check this
+        file next run". Dry-run and errors return False so the timestamp
+        isn't poisoned.
+        """
         if not self._track_map:
             msg = f"not removing tracks from mkv with no tracks: {self.path}"
             logger.error(msg)
@@ -272,7 +280,9 @@ class MKVFile:
             logger.info(f"\tAlready stripped {self.path}")
             self._reporter.stats.record_already_stripped()
             self._reporter.progress.mark_already_stripped()
-            return False
+            # Already in the desired state — let Walk write the timestamp
+            # so subsequent runs short-circuit on the timestamp check.
+            return True
 
         changed = False
         try:

--- a/nudebomb/walk.py
+++ b/nudebomb/walk.py
@@ -326,8 +326,11 @@ class Walk:
             return
         if self._is_path_before_timestamp(top_path, path):
             return
-        wrote = self.strip_path(top_path, path)
-        if self._timestamps and wrote:
+        # `up_to_date` is True for both freshly-remuxed files and files
+        # that were already stripped — both states mean "no need to
+        # re-check next run", so write the timestamp.
+        up_to_date = self.strip_path(top_path, path)
+        if self._timestamps and up_to_date:
             self._timestamps.set(top_path, path)
 
     # ------------------------------------------------------------------

--- a/tests/test_mkv.py
+++ b/tests/test_mkv.py
@@ -72,6 +72,19 @@ class TestMkv(DiffTracksTest):
         out_tracks = mkv_tracks(TEST_MKV)
         assert_eng_und_only(out_tracks)
 
+    def test_already_stripped_returns_true(self) -> None:
+        """
+        A second pass over an already-stripped file still reports True.
+
+        Walk relies on this to write a timestamp even when no remux was
+        needed, so subsequent runs short-circuit on the timestamp check.
+        """
+        first = MKVFile(self._config, TEST_MKV)
+        assert first.remove_tracks()
+
+        second = MKVFile(self._config, TEST_MKV)
+        assert second.remove_tracks()
+
     def test_fail(self) -> None:
         """Test fail."""
         self._config.languages = ["xxx"]


### PR DESCRIPTION
## Summary

\`MKVFile.remove_tracks()\` returned \`False\` for files that needed no work (\`if not num_remove_ids and not und_relabeled\`), so the timestamp branch in \`walk.walk_file\` (\`if self._timestamps and wrote: ...\`) never fired for them. Result: every subsequent run re-ran \`mkvmerge -J\` on already-stripped files instead of short-circuiting on the timestamp check.

Change the contract of \`remove_tracks()\`: returns \`True\` whenever the file is in the desired state — freshly remuxed OR already stripped. Dry-run and errors still return \`False\` so the timestamp isn't poisoned. Renamed the local in \`walk_file\` from \`wrote\` to \`up_to_date\` to match.

## Test plan

- [x] New \`test_already_stripped_returns_true\` in \`tests/test_mkv.py\` covers the contract: a second pass over a previously-stripped file still reports True
- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` all clean (65 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)