### PR TITLE
Replace dim style with bright_black for reliable rendering

### DIFF
--- a/nudebomb/cli.py
+++ b/nudebomb/cli.py
@@ -33,11 +33,11 @@ class CommaListAction(Action):
 
 
 CHAR_KEY: Final = (
-    (".", "dim", "MKV ignored/skipped"),
-    (".", "green dim", "MKV skipped (timestamp unchanged)"),
+    (".", "bright_black", "MKV ignored/skipped"),
+    (".", "bold bright_green", "MKV skipped (timestamp unchanged)"),
     (".", "green", "MKV already stripped"),
     ("*", "white", "MKV stripped tracks"),
-    ("*", "dim", "MKV not remuxed (dry run)"),
+    ("*", "bold bright_black", "MKV not remuxed (dry run)"),
     ("!", "yellow", "Warning"),
     ("X", "bold red", "Error"),
     ("O", "cyan", "Remote DB lookup succeeded"),

--- a/nudebomb/log/__init__.py
+++ b/nudebomb/log/__init__.py
@@ -21,8 +21,10 @@ console: Final[Console] = Console()
 # its own color/symbol so it pops next to neutral INFO lines.
 LOOKUP_HIT_LEVEL: Final = "DBHIT"
 
+# Level → Rich style. Avoid `dim` — some terminals render `\x1b[2m`
+# as literal escape text instead of fading the glyph.
 _LEVEL_STYLES: Final = {
-    "DEBUG": "dim",
+    "DEBUG": "bright_black",
     "INFO": "white",
     LOOKUP_HIT_LEVEL: "cyan",
     "SUCCESS": "green",

--- a/nudebomb/log/progress.py
+++ b/nudebomb/log/progress.py
@@ -34,17 +34,18 @@ __all__ = (
 )
 
 
-# (char, rich-style) pairs used by mark_* helpers below. Maps roughly to
-# the legacy termcolor scheme but consolidated so each *file* gets one
-# char and lookup events get their own.
+# (char, rich-style) pairs used by mark_* helpers below. Mirrors the
+# termcolor scheme of the original Printer (dark_grey == bright_black,
+# bold for emphasis) — Rich's `dim` style emits `\x1b[2m` which some
+# terminals render as literal escape text instead of fading the glyph.
 _CHARS: Final[Mapping[str, tuple[str, str]]] = MappingProxyType(
     {
         # Per-file marks
-        "ignored": (".", "dim"),
-        "skipped_timestamp": (".", "green dim"),
+        "ignored": (".", "bright_black"),
+        "skipped_timestamp": (".", "bold bright_green"),
         "already_stripped": (".", "green"),
         "stripped": ("*", "white"),
-        "dry_run": ("*", "dim"),
+        "dry_run": ("*", "bold bright_black"),
         "warning": ("!", "yellow"),
         "error": ("X", "bold red"),
         # Lookup marks (do not advance the bar)

--- a/nudebomb/log/summary.py
+++ b/nudebomb/log/summary.py
@@ -110,13 +110,17 @@ def _counts_table(stats: Stats) -> Table:
     table = Table(title="Summary", show_header=False, title_style="bold")
     table.add_column("Metric")
     table.add_column("Count", justify="right")
-    table.add_row("Ignored", str(stats.ignored), style="dim")
+    table.add_row("Ignored", str(stats.ignored), style="bright_black")
     table.add_row(
-        "Skipped (timestamp)", str(stats.skipped_timestamp), style="green dim"
+        "Skipped (timestamp)",
+        str(stats.skipped_timestamp),
+        style="bold bright_green",
     )
     table.add_row("Already stripped", str(stats.already_stripped), style="green")
     table.add_row("Stripped", str(len(stats.stripped)), style="white")
-    table.add_row("Not remuxed (dry run)", str(len(stats.dry_run)), style="dim")
+    table.add_row(
+        "Not remuxed (dry run)", str(len(stats.dry_run)), style="bold bright_black"
+    )
     table.add_row("Warnings", str(len(stats.warnings)), style="yellow")
     table.add_row("Errors", str(len(stats.errors)), style="bold red")
     table.add_row("DB cache hits", str(stats.db_cache_hits), style="cyan")
@@ -165,7 +169,7 @@ def render(stats: Stats, console: Console) -> None:
     """Print the summary to the given Rich console."""
     console.print(_counts_table(stats))
     _print_paths(console, "Stripped tracks", stats.stripped, "green")
-    _print_paths(console, "Not remuxed (dry run)", stats.dry_run, "dim")
+    _print_paths(console, "Not remuxed (dry run)", stats.dry_run, "bold bright_black")
     _print_pairs(console, "Warnings", stats.warnings, "yellow")
     _print_pairs(console, "Errors", stats.errors, "bold red")
     _print_messages(console, "DB lookups with no result", stats.db_no_results, "yellow")


### PR DESCRIPTION
## Summary

The progress bar's "ignored" mark (and other "dim"-styled output — log lines, summary rows, char-key legend) was rendering as literal \`[2m[90m.[0m\` text in some terminals instead of a faded dim glyph.

Root cause: Rich emits its \`dim\` style as the byte sequence \`\\x1b[2m\\x1b[90m\` (faint + bright_black). Some terminals don't interpret the \`\\x1b[2m\` faint sequence at all and end up displaying the surrounding bytes literally.

The original termcolor \`Printer\` used \`dark_grey\` (just \`\\x1b[90m\`, bright_black foreground, no faint), which works reliably everywhere. Restore that.

## What changed

- \`nudebomb/log/progress.py\` — \`CharStreamColumn\` styles for \`ignored\`, \`skipped_timestamp\`, \`dry_run\`. Where \`dim\` previously added emphasis (e.g. \`green dim\`), the replacement is \`bold\` + the bright variant.
- \`nudebomb/log/summary.py\` — matching summary table rows + the dry-run itemized list style.
- \`nudebomb/log/__init__.py\` — DEBUG level's loguru style.
- \`nudebomb/cli.py\` — help-epilogue char key.

## Test plan

- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (65 tests pass)
- [x] \`script\` recording of a \`-d -r\` run shows the bar's \`.\` chars emit \`\\x1b[90m.\\x1b[0m\` (bright_black only) — no \`\\x1b[2m\` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)