### PR TITLE
Disable repr-highlighter on the shared Rich Console

### DIFF
--- a/nudebomb/log/__init__.py
+++ b/nudebomb/log/__init__.py
@@ -15,7 +15,14 @@ __all__ = ("LOOKUP_HIT_LEVEL", "console", "logger", "setup")
 
 # Single Console for everything — both Rich Progress and the loguru sink
 # share it so the live region and log lines stay in sync.
-console: Final[Console] = Console()
+#
+# `highlight=False` is critical: the default repr-highlighter would
+# otherwise be applied to anything Rich re-prints internally, including
+# the rendered ANSI strings produced by the live progress bar. On some
+# installs that turns each `[` in `\x1b[Xm` sequences into a bold-styled
+# bracket and leaves the leading `\x1b` as a stray byte, so the dots
+# show up as literal `[2m[90m.[0m` text in the terminal.
+console: Final[Console] = Console(highlight=False)
 
 # Custom level for remote DB hits — sits at INFO numeric level but gets
 # its own color/symbol so it pops next to neutral INFO lines.


### PR DESCRIPTION
## Summary

Some Rich installs re-print the live progress bar's already-rendered ANSI output as a string with the default repr-highlighter enabled. The highlighter then re-styles every \`[\` byte inside the existing ANSI sequences (\`\\x1b[2m\`, \`\\x1b[90m\`, \`\\x1b[0m\`) — wrapping each in \`\\x1b[1m...\\x1b[0m\` (bold). The original leading \`\\x1b\` byte leaks through as a stray ESC, and the end result on screen is hundreds of lines of literal \`[2m[90m.[0m\` text scrolling past instead of bright_black dots.

Construct the shared \`Console\` with \`highlight=False\` so the auto-highlighter can't be applied to anything Rich emits — including its own internal Live-region re-renders. The per-call \`highlight=False\` in the loguru sink stays as belt-and-braces.

## How I traced it

\`od -c\` on a \`script(1)\`-captured run from the affected machine showed:

\`\`\`
\\033 [ 2 K \\033 \\033 [ 1 m [ \\033 [ 0 m 2 m \\033 \\033 [ 1 m [ \\033 [ 0 m 9 0 m . \\033 \\033 [ 1 m [ \\033 [ 0 m 0 m
\`\`\`

— a clear-line, then for each \`[\` from \`\\x1b[2m\\x1b[90m.\\x1b[0m\`: a stray ESC byte plus a bold-styled bracket. That's exactly Rich's repr-highlighter applied to the rendered ANSI string.

## Test plan

- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (65 tests pass)
- [ ] Verify on the affected Mac that the dots now render as bright_black (no \`[2m[90m.[0m\` literal text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)