### PR TITLE
Size the char-stream column to keep the progress bar single-line

### DIFF
--- a/nudebomb/log/progress.py
+++ b/nudebomb/log/progress.py
@@ -236,7 +236,16 @@ def make_progress(
     if not enabled or not console.is_terminal:
         return ProgressContext(enabled=False)
 
-    char_column = CharStreamColumn()
+    # Size the streaming-char column so the whole bar fits on one line.
+    # If the bar wraps, Rich's Live region flips into multi-line mode
+    # and emits `\n` per refresh — which scrolls each frame past instead
+    # of redrawing in place.
+    #
+    # Reserve ~46 chars for the other columns:
+    #   spinner(~2) + " Stripping MKVs "(16) + counts(~12) + time(~12) +
+    #   inter-column spaces. Cap the stream at 40 on very wide terminals.
+    char_width = max(8, min(40, console.width - 46))
+    char_column = CharStreamColumn(max_width=char_width)
     progress = Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),


### PR DESCRIPTION
## Summary

Follow-up to #51. After the highlighter fix, the dots render correctly on the affected machine but each one still ends up on its own line in scrollback. Suspected cause: the bar's total column width exceeds the terminal width, so Rich's Live region flips into multi-line mode and emits \`\\n\` per refresh — each frame then scrolls past instead of redrawing in place.

The fixed \`CharStreamColumn(max_width=40)\` plus the spinner, description, counts, and time columns add up to ~82 chars, which wraps on a default 80-col terminal. Compute the char-stream width from \`console.width\` instead — reserve ~46 chars for the rest of the bar and clamp the stream into \`[8, 40]\` so it always fits.

## Reviewer notes

- On wide terminals (>= 86 cols) the bar visually identical to before — clamped at 40.
- On narrow terminals the stream shortens but the bar stays single-line.
- Test plan unchanged; \`make test\` clean (65 pass).

## Verification on the affected Mac

After merging + pulling, please confirm the dots accumulate **inside** the bar at the bottom of the terminal rather than scrolling past. If the bug persists, please send:
- \`echo \$TERM && tput cols\` from the SSH session
- \`uv run python -c "import rich; print(rich.__version__)"\`
- A fresh \`script(1)\` byte-stream so I can see whether \`\\r\\n\` is still in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)