### PR TITLE
Use grey50 (256-color) instead of bright_black for grey marks

### DIFF
--- a/nudebomb/cli.py
+++ b/nudebomb/cli.py
@@ -33,11 +33,11 @@ class CommaListAction(Action):
 
 
 CHAR_KEY: Final = (
-    (".", "bright_black", "MKV ignored/skipped"),
+    (".", "grey50", "MKV ignored/skipped"),
     (".", "bold bright_green", "MKV skipped (timestamp unchanged)"),
     (".", "green", "MKV already stripped"),
     ("*", "white", "MKV stripped tracks"),
-    ("*", "bold bright_black", "MKV not remuxed (dry run)"),
+    ("*", "bold grey50", "MKV not remuxed (dry run)"),
     ("!", "yellow", "Warning"),
     ("X", "bold red", "Error"),
     ("O", "cyan", "Remote DB lookup succeeded"),

--- a/nudebomb/log/__init__.py
+++ b/nudebomb/log/__init__.py
@@ -28,10 +28,13 @@ console: Final[Console] = Console(highlight=False)
 # its own color/symbol so it pops next to neutral INFO lines.
 LOOKUP_HIT_LEVEL: Final = "DBHIT"
 
-# Level → Rich style. Avoid `dim` — some terminals render `\x1b[2m`
-# as literal escape text instead of fading the glyph.
+# Level → Rich style. Avoid `dim` (`\x1b[2m`) and `bright_black`
+# (`\x1b[90m`): some terminals render `\x1b[2m` as literal escape text,
+# and at least one Rich 15 env emits `bright_black` as `\x1b[2m\x1b[90m`
+# which cascades into broken Live-region rendering. `grey50` is a
+# single 256-color code (`\x1b[38;5;244m`) that renders reliably.
 _LEVEL_STYLES: Final = {
-    "DEBUG": "bright_black",
+    "DEBUG": "grey50",
     "INFO": "white",
     LOOKUP_HIT_LEVEL: "cyan",
     "SUCCESS": "green",

--- a/nudebomb/log/progress.py
+++ b/nudebomb/log/progress.py
@@ -35,17 +35,23 @@ __all__ = (
 
 
 # (char, rich-style) pairs used by mark_* helpers below. Mirrors the
-# termcolor scheme of the original Printer (dark_grey == bright_black,
-# bold for emphasis) — Rich's `dim` style emits `\x1b[2m` which some
-# terminals render as literal escape text instead of fading the glyph.
+# termcolor scheme of the original Printer (dark_grey == grey50).
+#
+# We deliberately avoid `dim` (`\x1b[2m`) and `bright_black` (`\x1b[90m`)
+# for the grey marks: some terminals render `\x1b[2m` as literal escape
+# text, and at least one user environment with Rich 15 emits
+# `bright_black` as `\x1b[2m\x1b[90m` (with a faint prefix) which then
+# cascades into Live-region wrapping issues. `grey50` resolves to a
+# single 256-color code (`\x1b[38;5;244m`) which is a separate code
+# path and renders cleanly everywhere we've tested.
 _CHARS: Final[Mapping[str, tuple[str, str]]] = MappingProxyType(
     {
         # Per-file marks
-        "ignored": (".", "bright_black"),
+        "ignored": (".", "grey50"),
         "skipped_timestamp": (".", "bold bright_green"),
         "already_stripped": (".", "green"),
         "stripped": ("*", "white"),
-        "dry_run": ("*", "bold bright_black"),
+        "dry_run": ("*", "bold grey50"),
         "warning": ("!", "yellow"),
         "error": ("X", "bold red"),
         # Lookup marks (do not advance the bar)

--- a/nudebomb/log/summary.py
+++ b/nudebomb/log/summary.py
@@ -110,7 +110,7 @@ def _counts_table(stats: Stats) -> Table:
     table = Table(title="Summary", show_header=False, title_style="bold")
     table.add_column("Metric")
     table.add_column("Count", justify="right")
-    table.add_row("Ignored", str(stats.ignored), style="bright_black")
+    table.add_row("Ignored", str(stats.ignored), style="grey50")
     table.add_row(
         "Skipped (timestamp)",
         str(stats.skipped_timestamp),
@@ -118,9 +118,7 @@ def _counts_table(stats: Stats) -> Table:
     )
     table.add_row("Already stripped", str(stats.already_stripped), style="green")
     table.add_row("Stripped", str(len(stats.stripped)), style="white")
-    table.add_row(
-        "Not remuxed (dry run)", str(len(stats.dry_run)), style="bold bright_black"
-    )
+    table.add_row("Not remuxed (dry run)", str(len(stats.dry_run)), style="bold grey50")
     table.add_row("Warnings", str(len(stats.warnings)), style="yellow")
     table.add_row("Errors", str(len(stats.errors)), style="bold red")
     table.add_row("DB cache hits", str(stats.db_cache_hits), style="cyan")
@@ -169,7 +167,7 @@ def render(stats: Stats, console: Console) -> None:
     """Print the summary to the given Rich console."""
     console.print(_counts_table(stats))
     _print_paths(console, "Stripped tracks", stats.stripped, "green")
-    _print_paths(console, "Not remuxed (dry run)", stats.dry_run, "bold bright_black")
+    _print_paths(console, "Not remuxed (dry run)", stats.dry_run, "bold grey50")
     _print_pairs(console, "Warnings", stats.warnings, "yellow")
     _print_pairs(console, "Errors", stats.errors, "bold red")
     _print_messages(console, "DB lookups with no result", stats.db_no_results, "yellow")


### PR DESCRIPTION
## Summary

On at least one Rich 15 / xterm-256color environment, the \`bright_black\` style is rendered as \`\\x1b[2m\\x1b[90m\` (faint prefix + 16-color extension) instead of plain \`\\x1b[90m\`. The unexpected \`\\x1b[2m\` then cascades into broken Live-region rendering — frames are split across visual lines and each progress mark scrolls past instead of staying in the bar.

I cannot reproduce the \`\\x1b[2m\` injection locally under any Rich 15 \`Console\` config (\`color_system\` × \`force_terminal\` × TERM × COLORTERM combinations all emit \`\\x1b[90m\` cleanly). So instead of chasing the upstream cause, this PR sidesteps the 16-color extension entirely.

## What changed

Replace every \`bright_black\` / \`bold bright_black\` style with \`grey50\` / \`bold grey50\`. \`grey50\` resolves to a single 256-color code (\`\\x1b[38;5;244m\`) which is a different code path from the 16-color bright extension and renders cleanly across every Rich color system I can test.

Touches:
- \`nudebomb/log/progress.py\` — \`CharStreamColumn\` styles for \`ignored\` / \`dry_run\`
- \`nudebomb/log/summary.py\` — matching summary table rows + dry-run itemized list
- \`nudebomb/log/__init__.py\` — DEBUG level loguru style
- \`nudebomb/cli.py\` — help-epilogue char key

## Test plan

- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (65 pass)
- [ ] On the affected Mac: \`script(1)\` capture should show \`\\x1b[38;5;244m.\\x1b[0m\` (no \`\\x1b[2m\` prefix) for ignored marks. The bar should redraw in place.

## If this *still* doesn't fix it

The remaining failure mode is the bar's per-frame line termination — your stream had \`\\r\\n\` between frames where mine has \`\\r\\n\` only at exit. If you still see scrolling after this lands, please send:

\`\`\`
uv run python -c "
from rich.console import Console
c = Console()
print('width:', c.width, 'is_terminal:', c.is_terminal,
      'color_system:', c.color_system, 'legacy_windows:', c.legacy_windows)
import os
print('TERM:', os.environ.get('TERM'))
print('COLORTERM:', os.environ.get('COLORTERM'))
"
\`\`\`

That should pin down whatever Rich-15 detection differs between our environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)