### PR TITLE
Silence treestamps's dot-printer and centralize output styles

### DIFF
--- a/nudebomb/cli.py
+++ b/nudebomb/cli.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 
 from nudebomb.config import NudebombConfig
 from nudebomb.log import setup as setup_logging
+from nudebomb.log.styles import MARKS
 from nudebomb.version import VERSION
 from nudebomb.walk import Walk
 
@@ -32,18 +33,21 @@ class CommaListAction(Action):
         setattr(namespace, self.dest, values)
 
 
-CHAR_KEY: Final = (
-    (".", "dim", "MKV ignored/skipped"),
-    (".", "bold bright_green", "MKV skipped (timestamp unchanged)"),
-    (".", "green", "MKV already stripped"),
-    ("*", "white", "MKV stripped tracks"),
-    ("*", "dim", "MKV not remuxed (dry run)"),
-    ("!", "yellow", "Warning"),
-    ("X", "bold red", "Error"),
-    ("O", "cyan", "Remote DB lookup succeeded"),
-    ("x", "yellow", "Remote DB lookup no result"),
-    ("X", "yellow", "Remote DB rate limited"),
-    ("X", "bold red", "Remote DB error"),
+# Order + label for each mark in the help epilogue legend. The char and
+# style are pulled from the centralized MARKS table so the legend can
+# never drift from what the bar actually renders.
+CHAR_KEY_LABELS: Final[tuple[tuple[str, str], ...]] = (
+    ("ignored", "MKV ignored/skipped"),
+    ("skipped_timestamp", "MKV skipped (timestamp unchanged)"),
+    ("already_stripped", "MKV already stripped"),
+    ("stripped", "MKV stripped tracks"),
+    ("dry_run", "MKV not remuxed (dry run)"),
+    ("warning", "Warning"),
+    ("error", "Error"),
+    ("lookup_hit", "Remote DB lookup succeeded"),
+    ("lookup_no_result", "Remote DB lookup no result"),
+    ("lookup_rate_limited", "Remote DB rate limited"),
+    ("lookup_error", "Remote DB error"),
 )
 
 
@@ -52,8 +56,9 @@ def get_progress_char_key() -> str:
     console = Console(record=True, force_terminal=True, no_color=False)
     console.begin_capture()
     console.print("[bold]Progress char key:[/bold]")
-    for char, style, label in CHAR_KEY:
-        console.print(f"\t[{style}]{char}[/{style}]  {label}")
+    for kind, label in CHAR_KEY_LABELS:
+        mark = MARKS[kind]
+        console.print(f"\t[{mark.style}]{mark.char}[/{mark.style}]  {label}")
     return console.end_capture()
 
 

--- a/nudebomb/log/__init__.py
+++ b/nudebomb/log/__init__.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Final
 from loguru import logger
 from rich.console import Console
 
+from nudebomb.log.styles import LEVEL_STYLES, LOOKUP_HIT_LEVEL
+
 if TYPE_CHECKING:
     from loguru import Record
 
@@ -23,19 +25,6 @@ __all__ = ("LOOKUP_HIT_LEVEL", "console", "logger", "setup")
 # bracket and leaves the leading `\x1b` as a stray byte, so the dots
 # show up as literal `[2m[90m.[0m` text in the terminal.
 console: Final[Console] = Console(highlight=False)
-
-# Custom level for remote DB hits — sits at INFO numeric level but gets
-# its own color/symbol so it pops next to neutral INFO lines.
-LOOKUP_HIT_LEVEL: Final = "DBHIT"
-
-_LEVEL_STYLES: Final = {
-    "DEBUG": "dim",
-    "INFO": "white",
-    LOOKUP_HIT_LEVEL: "cyan",
-    "SUCCESS": "green",
-    "WARNING": "yellow",
-    "ERROR": "bold red",
-}
 
 # verbose -> minimum loguru level to emit
 _VERBOSE_LEVEL: Final = {
@@ -55,7 +44,7 @@ def _sink(message: object) -> None:
     """Write a loguru record to the shared Rich console."""
     record: Record = message.record  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
     level = record["level"].name
-    style = _LEVEL_STYLES.get(level, "white")
+    style = LEVEL_STYLES.get(level, "white")
     text = record["message"]
     console.print(f"[{style}]{text}[/{style}]", highlight=False, soft_wrap=True)
 

--- a/nudebomb/log/progress.py
+++ b/nudebomb/log/progress.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import threading
 from collections import defaultdict, deque
 from contextlib import contextmanager
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Final
 
 from rich.progress import (
@@ -20,8 +19,10 @@ from rich.progress import (
 from rich.text import Text
 from typing_extensions import Self, override
 
+from nudebomb.log.styles import MARKS
+
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Mapping
+    from collections.abc import Callable, Generator
     from types import TracebackType
 
     from rich.console import Console
@@ -33,25 +34,6 @@ __all__ = (
     "make_progress",
 )
 
-
-# (char, rich-style) pairs used by mark_* helpers below.
-_CHARS: Final[Mapping[str, tuple[str, str]]] = MappingProxyType(
-    {
-        # Per-file marks
-        "ignored": (".", "dim"),
-        "skipped_timestamp": (".", "bold bright_green"),
-        "already_stripped": (".", "green"),
-        "stripped": ("*", "white"),
-        "dry_run": ("*", "dim"),
-        "warning": ("!", "yellow"),
-        "error": ("X", "bold red"),
-        # Lookup marks (do not advance the bar)
-        "lookup_hit": ("O", "cyan"),
-        "lookup_no_result": ("x", "yellow"),
-        "lookup_rate_limited": ("X", "yellow"),
-        "lookup_error": ("X", "bold red"),
-    }
-)
 
 # Marks that count as a finished file and advance the bar.
 _FILE_MARKS: Final = frozenset(
@@ -141,8 +123,8 @@ class ProgressContext:
             or self._task_id is None
         ):
             return
-        char, style = _CHARS[kind]
-        self._char_column.push(int(self._task_id), char, style)
+        mark = MARKS[kind]
+        self._char_column.push(int(self._task_id), mark.char, mark.style)
         if kind in _FILE_MARKS:
             self._progress.advance(self._task_id, 1)
 

--- a/nudebomb/log/styles.py
+++ b/nudebomb/log/styles.py
@@ -1,0 +1,90 @@
+"""
+Centralized color / style / char definitions for nudebomb output.
+
+Single source of truth for everything user-facing: the streaming-char
+column on the progress bar, the loguru sink that writes log lines, the
+end-of-run summary table, and the help-epilogue char-key legend.
+
+Why centralize: the same outcome (e.g. "ignored file") should read the
+same way on the bar, in the summary, and in the legend. Changing the
+visual treatment of any event should require editing exactly one
+place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = (
+    "LEVEL_STYLES",
+    "LOOKUP_HIT_LEVEL",
+    "MARKS",
+    "Mark",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Mark:
+    """A single (char, Rich-style) pair for a per-event progress mark."""
+
+    char: str
+    style: str
+
+
+# Custom loguru level for remote DB hits — sits at INFO numeric level
+# but gets its own color so it pops next to neutral INFO lines.
+LOOKUP_HIT_LEVEL: Final = "DBHIT"
+
+
+# Per-event marks. Keys mirror the names used by `Stats` / `mark_*`
+# helpers and the summary table rows.
+#
+# Style notes:
+#  - We avoid Rich's `dim` (`\x1b[2m`) and the 16-color `bright_black`
+#    extension (`\x1b[90m`) for the grey marks: some terminals render
+#    `\x1b[2m` as literal escape text, and at least one Rich 15
+#    environment renders `bright_black` with an unwanted faint prefix.
+#    `grey50` resolves to a single 256-color code (`\x1b[38;5;244m`)
+#    which renders cleanly everywhere.
+#  - `bold` is used as emphasis where the original termcolor scheme had
+#    `[bold]` (e.g. dry-run, timestamp-skipped).
+MARKS: Final[Mapping[str, Mark]] = MappingProxyType(
+    {
+        # Per-file marks (advance the bar)
+        "ignored": Mark(".", "grey50"),
+        "skipped_timestamp": Mark(".", "bold bright_green"),
+        "already_stripped": Mark(".", "green"),
+        "stripped": Mark("*", "white"),
+        "dry_run": Mark("*", "bold grey50"),
+        "warning": Mark("!", "yellow"),
+        "error": Mark("X", "bold red"),
+        # Lookup marks (do not advance the bar)
+        "lookup_hit": Mark("O", "cyan"),
+        "lookup_no_result": Mark("x", "yellow"),
+        "lookup_rate_limited": Mark("X", "yellow"),
+        "lookup_error": Mark("X", "bold red"),
+    }
+)
+
+
+def _style(key: str) -> str:
+    return MARKS[key].style
+
+
+# Loguru level → Rich style. Levels that correspond to a per-event mark
+# share that mark's style so log lines and progress chars match.
+LEVEL_STYLES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "DEBUG": _style("ignored"),
+        "INFO": _style("stripped"),
+        LOOKUP_HIT_LEVEL: _style("lookup_hit"),
+        "SUCCESS": _style("already_stripped"),
+        "WARNING": _style("warning"),
+        "ERROR": _style("error"),
+    }
+)

--- a/nudebomb/log/summary.py
+++ b/nudebomb/log/summary.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 from rich.table import Table
 
+from nudebomb.log.styles import MARKS
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -110,20 +112,36 @@ def _counts_table(stats: Stats) -> Table:
     table = Table(title="Summary", show_header=False, title_style="bold")
     table.add_column("Metric")
     table.add_column("Count", justify="right")
-    table.add_row("Ignored", str(stats.ignored), style="dim")
+    table.add_row("Ignored", str(stats.ignored), style=MARKS["ignored"].style)
     table.add_row(
         "Skipped (timestamp)",
         str(stats.skipped_timestamp),
-        style="bold bright_green",
+        style=MARKS["skipped_timestamp"].style,
     )
-    table.add_row("Already stripped", str(stats.already_stripped), style="green")
-    table.add_row("Stripped", str(len(stats.stripped)), style="white")
-    table.add_row("Not remuxed (dry run)", str(len(stats.dry_run)), style="dim")
-    table.add_row("Warnings", str(len(stats.warnings)), style="yellow")
-    table.add_row("Errors", str(len(stats.errors)), style="bold red")
-    table.add_row("DB cache hits", str(stats.db_cache_hits), style="cyan")
-    table.add_row("Remote DB hits", str(stats.db_remote_hits), style="cyan")
-    table.add_row("Langfile hits", str(stats.langfile_hits), style="cyan")
+    table.add_row(
+        "Already stripped",
+        str(stats.already_stripped),
+        style=MARKS["already_stripped"].style,
+    )
+    table.add_row("Stripped", str(len(stats.stripped)), style=MARKS["stripped"].style)
+    table.add_row(
+        "Not remuxed (dry run)",
+        str(len(stats.dry_run)),
+        style=MARKS["dry_run"].style,
+    )
+    table.add_row("Warnings", str(len(stats.warnings)), style=MARKS["warning"].style)
+    table.add_row("Errors", str(len(stats.errors)), style=MARKS["error"].style)
+    table.add_row(
+        "DB cache hits", str(stats.db_cache_hits), style=MARKS["lookup_hit"].style
+    )
+    table.add_row(
+        "Remote DB hits",
+        str(stats.db_remote_hits),
+        style=MARKS["lookup_hit"].style,
+    )
+    table.add_row(
+        "Langfile hits", str(stats.langfile_hits), style=MARKS["lookup_hit"].style
+    )
     return table
 
 
@@ -166,9 +184,20 @@ def _print_messages(
 def render(stats: Stats, console: Console) -> None:
     """Print the summary to the given Rich console."""
     console.print(_counts_table(stats))
-    _print_paths(console, "Stripped tracks", stats.stripped, "green")
-    _print_paths(console, "Not remuxed (dry run)", stats.dry_run, "dim")
-    _print_pairs(console, "Warnings", stats.warnings, "yellow")
-    _print_pairs(console, "Errors", stats.errors, "bold red")
-    _print_messages(console, "DB lookups with no result", stats.db_no_results, "yellow")
-    _print_messages(console, "Remote DB errors", stats.db_remote_errors, "bold red")
+    _print_paths(
+        console, "Stripped tracks", stats.stripped, MARKS["already_stripped"].style
+    )
+    _print_paths(
+        console, "Not remuxed (dry run)", stats.dry_run, MARKS["dry_run"].style
+    )
+    _print_pairs(console, "Warnings", stats.warnings, MARKS["warning"].style)
+    _print_pairs(console, "Errors", stats.errors, MARKS["error"].style)
+    _print_messages(
+        console,
+        "DB lookups with no result",
+        stats.db_no_results,
+        MARKS["lookup_no_result"].style,
+    )
+    _print_messages(
+        console, "Remote DB errors", stats.db_remote_errors, MARKS["error"].style
+    )

--- a/nudebomb/walk.py
+++ b/nudebomb/walk.py
@@ -352,10 +352,14 @@ class Walk:
         logger.info("Searching for MKV files to process…")
 
         if self._config.timestamps:
+            # Force `verbose=0` so treestamps's own termcolor Printer
+            # stays silent. At verbose>=1 it would emit `\x1b[2m\x1b[90m.`
+            # dots straight to stdout for each `.set()` call, bypassing
+            # rich's Live region and breaking the bar's in-place redraw.
             grove_config = GrovestampsConfig(
                 PROGRAM_NAME,
                 paths=self._config.paths,
-                verbose=self._config.verbose,
+                verbose=0,
                 symlinks=self._config.symlinks,
                 ignore=self._config.ignore,
                 check_config=self._config.timestamps_check_config,


### PR DESCRIPTION
## Summary

The mystery grey dots that scrolled past the progress bar were not coming from nudebomb at all — they were from \`treestamps\`. Its internal \`Printer\` ([\`treestamps/printer.py:29\`](https://github.com/ajslater/treestamps/blob/HEAD/treestamps/printer.py)) emits \`cprint(".", "dark_grey", attrs=["dark"], end="", flush=True)\` for every \`.set()\` call when \`verbose>=1\`, writing \`\\x1b[2m\\x1b[90m.\\x1b[0m\` straight to stdout and bypassing rich's Live region. That explains why the dots persisted even after AJ renamed the in-bar progress chars to \`I\`/\`S\`/\`A\` for debugging — the bar's chars were the centralized ones, but the *scrolling* dots were from a sibling library doing its own termcolor I/O.

The fix: pass \`verbose=0\` into \`GrovestampsConfig\` so treestamps stays silent. The trade-off is losing treestamps's own warnings/errors, which are rare edge cases worth the readable output.

## Centralization

Per AJ's request, every user-facing style/char now lives in a single new module:

- \`nudebomb/log/styles.py\`
  - \`MARKS: Mapping[str, Mark]\` — single source of truth for the (char, Rich-style) pair per event (\`ignored\`, \`stripped\`, \`dry_run\`, \`warning\`, \`error\`, \`lookup_*\`, …).
  - \`LEVEL_STYLES: Mapping[str, str]\` — loguru level → Rich style, derived from \`MARKS\` so log lines and progress chars agree.
  - \`LOOKUP_HIT_LEVEL\` constant moved here from \`log/__init__.py\`.

Consumers updated to import from \`styles\`:
- \`log/progress.py\` — \`CharStreamColumn\` reads char/style from \`MARKS[kind]\`
- \`log/summary.py\` — every \`Table.add_row\` and itemized-list \`_print_*\` reads style from \`MARKS\`
- \`log/__init__.py\` — loguru sink reads from \`LEVEL_STYLES\`
- \`cli.py\` — help-epilogue char-key built from \`MARKS\` via a new \`CHAR_KEY_LABELS\` order/label table

Now changing the visual treatment of any event is a single-line edit.

## Test plan

- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (65 pass)
- [ ] Verify on the affected Mac that the run no longer scrolls dots past the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)