### PR TITLE
Prune irrelevant rows from the summary table

### DIFF
--- a/nudebomb/log/summary.py
+++ b/nudebomb/log/summary.py
@@ -22,6 +22,13 @@ __all__ = ("Stats", "render")
 class Stats:
     """Thread-safe counters and itemized lists for the end-of-run summary."""
 
+    # Mode flags set once at construction so the summary table can hide
+    # rows that are irrelevant to this run (e.g. don't show
+    # "Skipped (timestamp)" when timestamps mode wasn't enabled).
+    timestamps_active: bool = False
+    dry_run_active: bool = False
+    remote_db_active: bool = False
+
     ignored: int = 0
     skipped_timestamp: int = 0
     already_stripped: int = 0
@@ -113,32 +120,39 @@ def _counts_table(stats: Stats) -> Table:
     table.add_column("Metric")
     table.add_column("Count", justify="right")
     table.add_row("Ignored", str(stats.ignored), style=MARKS["ignored"].style)
-    table.add_row(
-        "Skipped (timestamp)",
-        str(stats.skipped_timestamp),
-        style=MARKS["skipped_timestamp"].style,
-    )
+    if stats.timestamps_active:
+        table.add_row(
+            "Skipped (timestamp)",
+            str(stats.skipped_timestamp),
+            style=MARKS["skipped_timestamp"].style,
+        )
     table.add_row(
         "Already stripped",
         str(stats.already_stripped),
         style=MARKS["already_stripped"].style,
     )
     table.add_row("Stripped", str(len(stats.stripped)), style=MARKS["stripped"].style)
-    table.add_row(
-        "Not remuxed (dry run)",
-        str(len(stats.dry_run)),
-        style=MARKS["dry_run"].style,
-    )
-    table.add_row("Warnings", str(len(stats.warnings)), style=MARKS["warning"].style)
-    table.add_row("Errors", str(len(stats.errors)), style=MARKS["error"].style)
+    if stats.dry_run_active:
+        table.add_row(
+            "Not remuxed (dry run)",
+            str(len(stats.dry_run)),
+            style=MARKS["dry_run"].style,
+        )
+    if stats.warnings:
+        table.add_row(
+            "Warnings", str(len(stats.warnings)), style=MARKS["warning"].style
+        )
+    if stats.errors:
+        table.add_row("Errors", str(len(stats.errors)), style=MARKS["error"].style)
     table.add_row(
         "DB cache hits", str(stats.db_cache_hits), style=MARKS["lookup_hit"].style
     )
-    table.add_row(
-        "Remote DB hits",
-        str(stats.db_remote_hits),
-        style=MARKS["lookup_hit"].style,
-    )
+    if stats.remote_db_active:
+        table.add_row(
+            "Remote DB hits",
+            str(stats.db_remote_hits),
+            style=MARKS["lookup_hit"].style,
+        )
     table.add_row(
         "Langfile hits", str(stats.langfile_hits), style=MARKS["lookup_hit"].style
     )

--- a/nudebomb/walk.py
+++ b/nudebomb/walk.py
@@ -40,7 +40,11 @@ class Walk:
     def __init__(self, config: AttrDict) -> None:
         """Initialize."""
         self._config: AttrDict = config
-        self._stats: Stats = Stats()
+        self._stats: Stats = Stats(
+            timestamps_active=bool(config.timestamps or config.after),
+            dry_run_active=bool(config.dry_run),
+            remote_db_active=bool(config.tmdb_api_key or config.tvdb_api_key),
+        )
         # Progress is built later (in run()) once we know the total count.
         self._reporter: Reporter = Reporter(stats=self._stats)
         self._langfiles: LangFiles = LangFiles(config, stats=self._stats)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -51,14 +51,18 @@ class TestStats:
         assert stats.db_remote_errors == ["rate limited"]
 
 
+def _render(stats: Stats) -> str:
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, width=120)
+    render(stats, console)
+    return buffer.getvalue()
+
+
 class TestRender:
     """render() prints a counts table and itemized lists."""
 
     def test_empty_stats_renders_just_table(self) -> None:
-        buffer = io.StringIO()
-        console = Console(file=buffer, force_terminal=False, width=120)
-        render(Stats(), console)
-        output = buffer.getvalue()
+        output = _render(Stats())
         # Counts table is always present
         assert "Summary" in output
         # No itemized sections when lists are empty (the table includes
@@ -68,7 +72,11 @@ class TestRender:
         assert "Errors:" not in output
 
     def test_renders_itemized_lists(self) -> None:
-        stats = Stats()
+        stats = Stats(
+            timestamps_active=True,
+            dry_run_active=True,
+            remote_db_active=True,
+        )
         stats.record_stripped(Path("/a.mkv"))
         stats.record_dry_run(Path("/b.mkv"))
         stats.record_warning(Path("/c.mkv"), "weird")
@@ -76,10 +84,7 @@ class TestRender:
         stats.record_db_no_result("missing one")
         stats.record_db_remote_error("rate limited")
 
-        buffer = io.StringIO()
-        console = Console(file=buffer, force_terminal=False, width=120)
-        render(stats, console)
-        output = buffer.getvalue()
+        output = _render(stats)
 
         assert "Stripped tracks" in output
         assert "/a.mkv" in output
@@ -93,3 +98,46 @@ class TestRender:
         assert "missing one" in output
         assert "Remote DB errors" in output
         assert "rate limited" in output
+
+
+class TestConditionalRows:
+    """Mode-specific summary rows are hidden when their mode is inactive."""
+
+    def test_default_hides_mode_specific_rows(self) -> None:
+        output = _render(Stats())
+        # Mode flags are False, no warnings/errors
+        assert "Skipped (timestamp)" not in output
+        assert "Not remuxed (dry run)" not in output
+        assert "Remote DB hits" not in output
+        assert "Warnings" not in output
+        assert "Errors" not in output
+        # Always-shown rows still appear
+        assert "Ignored" in output
+        assert "Already stripped" in output
+        assert "Stripped" in output
+        assert "DB cache hits" in output
+        assert "Langfile hits" in output
+
+    def test_timestamps_active_shows_skipped_row(self) -> None:
+        output = _render(Stats(timestamps_active=True))
+        assert "Skipped (timestamp)" in output
+
+    def test_dry_run_active_shows_dry_run_row(self) -> None:
+        output = _render(Stats(dry_run_active=True))
+        assert "Not remuxed (dry run)" in output
+
+    def test_remote_db_active_shows_remote_db_hits_row(self) -> None:
+        output = _render(Stats(remote_db_active=True))
+        assert "Remote DB hits" in output
+
+    def test_warnings_row_shown_only_when_warnings_present(self) -> None:
+        stats = Stats()
+        stats.record_warning(Path("/x.mkv"), "weird")
+        output = _render(stats)
+        assert "Warnings" in output
+
+    def test_errors_row_shown_only_when_errors_present(self) -> None:
+        stats = Stats()
+        stats.record_error(Path("/x.mkv"), "boom")
+        output = _render(stats)
+        assert "Errors" in output

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -35,6 +35,8 @@ def _make_walk(
         symlinks=True,
         cache_expiry_days=30,
         after=None,
+        timestamps=False,
+        dry_run=False,
         lookup_workers=4,
     )
     return Walk(cfg)  # pyright: ignore[reportArgumentType], #ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

Five summary rows now only appear when they're meaningful for the current run:

| Row | Condition |
|---|---|
| Skipped (timestamp) | \`--timestamps\` or \`--after\` mode active |
| Not remuxed (dry run) | \`--dry-run\` active |
| Remote DB hits | \`--tmdb-api-key\` or \`--tvdb-api-key\` configured |
| Warnings | warnings list non-empty |
| Errors | errors list non-empty |

The always-shown rows (Ignored, Already stripped, Stripped, DB cache hits, Langfile hits) reflect the default operation regardless of mode.

## How

Three mode flags added to \`Stats\` (\`timestamps_active\`, \`dry_run_active\`, \`remote_db_active\`), populated once at construction time in \`Walk.__init__\` from the resolved config. \`_counts_table\` gates each conditional row on the matching flag (or on list non-emptiness for warnings/errors).

## Test plan

- [x] New \`TestConditionalRows\` covers each gate (default hides them, each flag/list shows the corresponding row)
- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (71 pass)
- [x] Manual smoke:
  - default run: 5 rows (Ignored, Already stripped, Stripped, DB cache hits, Langfile hits)
  - \`-d\` run: + Not remuxed (dry run)
  - \`-t\` run: + Skipped (timestamp), and the count increments correctly on the second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)