### PR TITLE
Log timestamps load/dump operations at INFO

### DIFF
--- a/nudebomb/walk.py
+++ b/nudebomb/walk.py
@@ -371,6 +371,8 @@ class Walk:
                 program_config_keys=TIMESTAMPS_CONFIG_KEYS,
             )
             self._timestamps = Grovestamps(grove_config)
+            for top_path in self._timestamps:
+                logger.info(f"Read timestamps from {top_path}")
 
         total = self._count_total()
         progress = make_progress(total, console, enabled=self._config.verbose > 0)
@@ -397,6 +399,8 @@ class Walk:
 
         if self._timestamps:
             self._timestamps.dumpf()
+            for top_path in self._timestamps:
+                logger.info(f"Saved timestamps for {top_path}")
 
         if self._config.verbose > 0:
             render_summary(self._stats, console)


### PR DESCRIPTION
## Summary

Treestamps 4 stopped emitting its own load/save messages. Restore the visibility from nudebomb's side:

- After \`Grovestamps()\` construction → \`logger.info(f"Read timestamps from {top_path}")\` for each root in the grove.
- After \`Grovestamps.dumpf()\` → \`logger.info(f"Saved timestamps for {top_path}")\` for each root.

INFO level (visible at \`-v\` / verbose=2). One line per root path so multi-path runs show every tree.

## Test plan

- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (71 pass)
- [x] Manual smoke: \`uv run nudebomb -v -t ...\` prints \`Read timestamps from <path>\` then \`Saved timestamps for <path>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)