### PR TITLE
Stream mkvmerge output above the live progress bar

### DIFF
--- a/nudebomb/mkv.py
+++ b/nudebomb/mkv.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final
 from loguru import logger
 
 from nudebomb.langfiles import lang_to_alpha3
+from nudebomb.log import console
 from nudebomb.log.reporter import Reporter
 from nudebomb.track import Track
 
@@ -172,9 +173,13 @@ class MKVFile:
         Drive a transient per-file sub-task on the shared Rich Progress
         from mkvmerge's ``--gui-mode`` progress lines (``#GUI#progress NN%``)
         so the percentage renders beneath the main bar inside the same
-        Live region instead of fighting it via raw stdout writes.
+        Live region. Other (human-readable) lines from mkvmerge are
+        printed through the shared Console so they scroll above the bar
+        like log output — Rich keeps the bar pinned beneath them via
+        the active Live region.
         """
         gui_command = [command[0], "--gui-mode", *command[1:]]
+        show_output = self._config.verbose > 0
         with (
             self._reporter.progress.file_subtask(f"  {self.path.name}") as update_pct,
             subprocess.Popen(  # noqa: S603
@@ -187,13 +192,20 @@ class MKVFile:
         ):
             stderr_chunks: list[str] = []
             if process.stdout is not None:
-                for line in process.stdout:
+                for raw_line in process.stdout:
+                    line = raw_line.rstrip()
                     if line.startswith("#GUI#progress"):
                         try:
-                            pct = int(line.strip().split()[-1].rstrip("%"))
+                            pct = int(line.split()[-1].rstrip("%"))
                         except (IndexError, ValueError):
                             continue
                         update_pct(pct)
+                    elif line.startswith("#GUI#"):
+                        # Other GUI markers (begin/end_scanning_playlists,
+                        # etc.) carry no human-readable info — skip.
+                        continue
+                    elif line and show_output:
+                        console.print(line, highlight=False)
             if process.stderr is not None:
                 stderr_chunks.append(process.stderr.read())
 


### PR DESCRIPTION
## Summary

Previously \`_remux_file\` parsed mkvmerge's \`--gui-mode\` stdout for just the \`#GUI#progress NN%\` lines (which drove the per-file sub-task percentage) and silently discarded everything else. The human-readable lines — file demultiplexer, output module per track, "The cue entries are being written…", "Multiplexing took N seconds" — were useful context that we threw away. The visible result was just one rolling percentage with no surrounding info.

Route those non-progress lines through the shared rich Console with \`console.print(line, highlight=False)\`. Rich's active Live region inserts each line above the bar and re-renders the bar beneath, so mkvmerge's output scrolls through normally and the bar stays pinned at the bottom — matching how the loguru sink already prints log lines.

## Filter

| Line | Behavior |
|---|---|
| \`#GUI#progress NN%\` | drives the sub-task percentage (unchanged) |
| other \`#GUI#…\` markers (e.g. \`begin/end_scanning_playlists\`) | skipped (no human-readable info) |
| everything else | \`console.print\` when verbose > 0 |

Suppressed at quiet (\`-q\` / verbose=0) so silent runs stay silent.

## Sample output (verbose=1)

\`\`\`
mkvmerge v98.0 ('Chonks') 64-bit
'/tmp/nb-mkv/test5.mkv': Using the demultiplexer for the format 'Matroska'.
'/tmp/nb-mkv/test5.mkv' track 0: Using the output module for the format 'AVC/H.264'.
'/tmp/nb-mkv/test5.mkv' track 1: Using the output module for the format 'AAC'.
…
The file '/tmp/nb-mkv/test5.mkv.tmp' has been opened for writing.
The cue entries (the index) are being written...
Multiplexing took 0 seconds.
[bar redraws beneath each line]
\`\`\`

## Test plan

- [x] \`make lint\`, \`make typecheck\`, \`make ty\`, \`make test\` clean (71 pass)
- [x] Manual smoke confirms the full mkvmerge multi-line output scrolls above the bar in real time, summary follows after Live exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)