### PR TITLE
Migrate to confuse 2.2.0 via typed NudebombSettings dataclass

### DIFF
--- a/nudebomb/config.py
+++ b/nudebomb/config.py
@@ -1,20 +1,24 @@
 """Confuse config for nudebomb."""
 
+from __future__ import annotations
+
 import os
 import sys
-from argparse import Namespace
-from pathlib import Path
+from dataclasses import dataclass
 from platform import system
 from time import mktime
-from typing import Final
+from typing import TYPE_CHECKING, Final, TypedDict, cast
 
 from confuse import Configuration
-from confuse.templates import AttrDict, Integer, MappingTemplate, Optional, Sequence
+from confuse.templates import Integer, MappingTemplate, Optional, Sequence
 from dateutil.parser import parse
 from loguru import logger
 
-from nudebomb.langfiles import lang_to_alpha3
+from nudebomb.lang import lang_to_alpha3
 from nudebomb.version import PROGRAM_NAME
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 TEMPLATE: Final = MappingTemplate(
     {
@@ -61,6 +65,89 @@ TIMESTAMPS_CONFIG_KEYS: Final = frozenset(
 
 if system() == "Windows":
     os.system("color")  # noqa: S605, S607
+
+
+@dataclass(slots=True)
+class NudebombSettings:
+    """
+    Typed runtime config for nudebomb.
+
+    Built once by :meth:`NudebombConfig.get_config` from a confuse-validated
+    ``AttrDict``; every downstream module takes ``NudebombSettings`` so
+    consumers never have to touch the loosely-typed AttrDict.
+
+    Not ``frozen``: ``Walk.strip_path`` deepcopies the run-wide settings
+    and overrides ``languages`` per-file from a discovered langfile, and
+    ``MKVFile.update_languages`` augments it again after a DB lookup
+    resolves. Both paths mutate the per-file copy, never the run-wide
+    instance.
+    """
+
+    # Sequence-shaped fields. ``languages`` and ``sub_languages`` use
+    # ``frozenset`` because consumers do set-algebra on them
+    # (``config.languages | {lang}``); ``paths`` and ``ignore`` keep
+    # iteration order so ``tuple`` is right.
+    paths: tuple[str, ...]
+    languages: frozenset[str]
+    sub_languages: frozenset[str] | None
+    ignore: tuple[str, ...]
+
+    # Numeric fields
+    after: float | None
+    cache_expiry_days: int
+    lookup_workers: int
+    verbose: int
+
+    # String fields
+    media_type: str | None
+    mkvmerge_bin: str
+    tmdb_api_key: str | None
+    tvdb_api_key: str | None
+    und_language: str | None
+
+    # Boolean fields
+    dry_run: bool
+    recurse: bool
+    strip_und_language: bool
+    subtitles: bool
+    symlinks: bool
+    timestamps: bool
+    timestamps_check_config: bool
+    title: bool
+
+
+class _NudebombSchema(TypedDict):
+    """
+    Static-typing view of the nudebomb section of the validated AttrDict.
+
+    confuse 2.2.0 returns ``AttrDict[str, object]`` from ``MappingTemplate``;
+    the runtime types are guaranteed by ``TEMPLATE`` validation. This
+    TypedDict declares those types so the conversion in
+    :meth:`NudebombConfig.get_config` type-checks via a single ``cast``
+    rather than a per-field cast.
+    """
+
+    after: float | None
+    cache_expiry_days: int
+    dry_run: bool
+    ignore: list[str]
+    languages: list[str]
+    lookup_workers: int
+    media_type: str | None
+    mkvmerge_bin: str
+    paths: list[str]
+    recurse: bool
+    strip_und_language: bool
+    sub_languages: list[str] | None
+    subtitles: bool
+    symlinks: bool
+    timestamps: bool
+    timestamps_check_config: bool
+    title: bool
+    tmdb_api_key: str | None
+    tvdb_api_key: str | None
+    und_language: str | None
+    verbose: int
 
 
 class NudebombConfig:
@@ -130,12 +217,49 @@ class NudebombConfig:
         ]["dry_run"].get(bool)
         config[PROGRAM_NAME]["timestamps"].set(timestamps)
 
+    @staticmethod
+    def _to_settings(nb_attrdict: object) -> NudebombSettings:
+        """
+        Convert the validated nudebomb AttrDict into a typed Settings.
+
+        Accepts ``object`` because confuse 2.2.0's typing for the inner
+        AttrDict (``AttrDict[str, int | str | list[str] | None]``) and our
+        ``_NudebombSchema`` TypedDict don't formally overlap; the cast
+        through ``object`` is the documented escape hatch for crossing
+        between confuse's runtime-validated dict and a TypedDict view.
+        """
+        nb = cast("_NudebombSchema", nb_attrdict)
+        sub_langs = nb["sub_languages"]
+        return NudebombSettings(
+            paths=tuple(nb["paths"]),
+            languages=frozenset(nb["languages"]),
+            sub_languages=frozenset(sub_langs) if sub_langs else None,
+            ignore=tuple(nb["ignore"]),
+            after=nb["after"],
+            cache_expiry_days=nb["cache_expiry_days"],
+            lookup_workers=nb["lookup_workers"],
+            verbose=nb["verbose"],
+            media_type=nb["media_type"],
+            mkvmerge_bin=nb["mkvmerge_bin"],
+            tmdb_api_key=nb["tmdb_api_key"],
+            tvdb_api_key=nb["tvdb_api_key"],
+            und_language=nb["und_language"],
+            dry_run=nb["dry_run"],
+            recurse=nb["recurse"],
+            strip_und_language=nb["strip_und_language"],
+            subtitles=nb["subtitles"],
+            symlinks=nb["symlinks"],
+            timestamps=nb["timestamps"],
+            timestamps_check_config=nb["timestamps_check_config"],
+            title=nb["title"],
+        )
+
     def get_config(
         self,
         args: Namespace | None = None,
         modname: str = PROGRAM_NAME,
-    ) -> AttrDict:
-        """Get the config dict, layering env and args over defaults."""
+    ) -> NudebombSettings:
+        """Get the typed config, layering env and args over defaults."""
         config = Configuration(PROGRAM_NAME, modname=modname, read=False)
         try:
             config.read()
@@ -153,10 +277,8 @@ class NudebombConfig:
         self._set_unique_lang_list(config, "sub_languages")
         self._set_ignore(config)
         self._set_timestamps(config)
+        # confuse 2.2.0 types the result of ``config.get(TEMPLATE)``
+        # precisely from the MappingTemplate, so an ``isinstance``
+        # narrowing is no longer needed.
         ad = config.get(TEMPLATE)
-        if not isinstance(ad, AttrDict):
-            raise TypeError
-        ad.paths = sorted(
-            frozenset(str(Path(path).resolve()) for path in ad.nudebomb.paths)
-        )
-        return ad.nudebomb
+        return self._to_settings(ad.nudebomb)

--- a/nudebomb/lang.py
+++ b/nudebomb/lang.py
@@ -1,0 +1,32 @@
+"""
+Language-code utilities.
+
+Lives in its own module so both ``nudebomb.config`` and
+``nudebomb.langfiles`` can depend on it without forming an import
+cycle (``langfiles`` takes ``NudebombSettings`` for type-checking;
+``config`` previously imported ``lang_to_alpha3`` from ``langfiles``,
+which would close the loop).
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+import pycountry
+from loguru import logger
+
+
+def lang_to_alpha3(lang: str) -> str:
+    """Convert a language code to ISO 639-3 (alpha3) format."""
+    if not lang:
+        return "und"
+    match len(lang):
+        case 3:
+            return lang
+        case 2:
+            with suppress(Exception):
+                if lo := pycountry.languages.get(alpha_2=lang):
+                    return lo.alpha_3
+        case _:
+            logger.warning(f"Languages should be in two or three letter format: {lang}")
+    return lang

--- a/nudebomb/langfiles.py
+++ b/nudebomb/langfiles.py
@@ -2,44 +2,29 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
 from typing import TYPE_CHECKING, Final
 
-import pycountry
 from loguru import logger
+
+from nudebomb.lang import lang_to_alpha3
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from confuse import AttrDict
-
+    from nudebomb.config import NudebombSettings
     from nudebomb.log.summary import Stats
 
+__all__ = ("LANGS_FNS", "LangFiles", "lang_to_alpha3")
+
 LANGS_FNS: Final = frozenset({"lang", "langs", ".lang", ".langs"})
-
-
-def lang_to_alpha3(lang: str) -> str:
-    """Convert a language code to ISO 639-3 (alpha3) format."""
-    if not lang:
-        return "und"
-    match len(lang):
-        case 3:
-            return lang
-        case 2:
-            with suppress(Exception):
-                if lo := pycountry.languages.get(alpha_2=lang):
-                    return lo.alpha_3
-        case _:
-            logger.warning(f"Languages should be in two or three letter format: {lang}")
-    return lang
 
 
 class LangFiles:
     """Process nudebomb langfiles."""
 
-    def __init__(self, config: AttrDict, stats: Stats | None = None) -> None:
+    def __init__(self, config: NudebombSettings, stats: Stats | None = None) -> None:
         """Initialize."""
-        self._config: AttrDict = config
+        self._config: NudebombSettings = config
         self._lang_roots: dict[Path, set[str]] = {}
         self._languages: frozenset[str] = frozenset(
             lang_to_alpha3(lang) for lang in self._config.languages

--- a/nudebomb/lookup/tmdb.py
+++ b/nudebomb/lookup/tmdb.py
@@ -17,8 +17,7 @@ from nudebomb.lookup.util import format_title_year, resolve_language
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from confuse import AttrDict
-
+    from nudebomb.config import NudebombSettings
     from nudebomb.lookup.parser import ParseResult
 
 _RATE_LIMIT_STATUS: Final = 429
@@ -27,12 +26,14 @@ _RATE_LIMIT_STATUS: Final = 429
 class TMDBLookup:
     """Look up original language of media from TMDB."""
 
-    def __init__(self, config: AttrDict, reporter: Reporter | None = None) -> None:
+    def __init__(
+        self, config: NudebombSettings, reporter: Reporter | None = None
+    ) -> None:
         """Initialize."""
         tmdb.API_KEY = config.tmdb_api_key
         self._reporter: Reporter = reporter if reporter is not None else Reporter()
         self._cache = LookupCache(config.cache_expiry_days, self._reporter)
-        self._media_type: str = config.media_type
+        self._media_type: str = config.media_type or ""
 
     def _search_tmdb(
         self, title: str, year: str = "", media_type: str = ""

--- a/nudebomb/lookup/tvdb.py
+++ b/nudebomb/lookup/tvdb.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Final
 import tvdb_v4_official
 from loguru import logger
 
-from nudebomb.langfiles import lang_to_alpha3
+from nudebomb.lang import lang_to_alpha3
 from nudebomb.log import LOOKUP_HIT_LEVEL
 from nudebomb.log.reporter import Reporter
 from nudebomb.lookup.cache import LookupCache
@@ -17,8 +17,7 @@ from nudebomb.lookup.parser import parse_title
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from confuse import AttrDict
-
+    from nudebomb.config import NudebombSettings
     from nudebomb.lookup.parser import ParseResult
 
 # Loose rate-limit heuristics: TVDB surfaces errors as ``{"code": int,
@@ -41,8 +40,13 @@ def _is_tvdb_error_dict(result: object) -> bool:
 class TVDBLookup:
     """Look up original language of TV series from TVDB."""
 
-    def __init__(self, config: AttrDict, reporter: Reporter | None = None) -> None:
+    def __init__(
+        self, config: NudebombSettings, reporter: Reporter | None = None
+    ) -> None:
         """Initialize."""
+        if not config.tvdb_api_key:
+            msg = "TVDBLookup requires a tvdb_api_key in config"
+            raise ValueError(msg)
         self._tvdb = tvdb_v4_official.TVDB(config.tvdb_api_key)
         # tvdb_v4_official stores pagination state on the shared Request
         # object; serialize HTTP calls to keep that state consistent.

--- a/nudebomb/lookup/util.py
+++ b/nudebomb/lookup/util.py
@@ -1,6 +1,6 @@
 """Utility functions for the lookup module."""
 
-from nudebomb.langfiles import lang_to_alpha3
+from nudebomb.lang import lang_to_alpha3
 
 
 def resolve_language(result: dict) -> str | None:

--- a/nudebomb/mkv.py
+++ b/nudebomb/mkv.py
@@ -10,13 +10,13 @@ from typing import TYPE_CHECKING, Final
 
 from loguru import logger
 
-from nudebomb.langfiles import lang_to_alpha3
+from nudebomb.lang import lang_to_alpha3
 from nudebomb.log import console
 from nudebomb.log.reporter import Reporter
 from nudebomb.track import Track
 
 if TYPE_CHECKING:
-    from confuse import AttrDict
+    from nudebomb.config import NudebombSettings
 
 
 class MKVFile:
@@ -28,10 +28,13 @@ class MKVFile:
     REMOVABLE_TRACK_NAMES: Final = (AUDIO_TRACK_NAME, SUBTITLE_TRACK_NAME)
 
     def __init__(
-        self, config: AttrDict, path: Path, reporter: Reporter | None = None
+        self,
+        config: NudebombSettings,
+        path: Path,
+        reporter: Reporter | None = None,
     ) -> None:
         """Initialize."""
-        self._config: AttrDict = config
+        self._config: NudebombSettings = config
         self.path: Path = Path(path)
         self._reporter: Reporter = reporter if reporter is not None else Reporter()
         self._init_track_map()

--- a/nudebomb/walk.py
+++ b/nudebomb/walk.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
 from copy import deepcopy
+from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -24,7 +25,7 @@ from nudebomb.mkv import MKVFile
 from nudebomb.version import PROGRAM_NAME
 
 if TYPE_CHECKING:
-    from confuse import AttrDict
+    from nudebomb.config import NudebombSettings
 
 # Canonical key shape: (namespace, key_a, key_b). Namespaces are cheap
 # strings so the same dict handles both id-based and title-based lookups.
@@ -37,9 +38,9 @@ _MAX_LOOKUP_WORKERS: Final = 8
 class Walk:
     """Directory traversal class."""
 
-    def __init__(self, config: AttrDict) -> None:
+    def __init__(self, config: NudebombSettings) -> None:
         """Initialize."""
-        self._config: AttrDict = config
+        self._config: NudebombSettings = config
         self._stats: Stats = Stats(
             timestamps_active=bool(config.timestamps or config.after),
             dry_run_active=bool(config.dry_run),
@@ -181,7 +182,7 @@ class Walk:
         Matches the cache keys used by :class:`LookupCache` so two files
         that would hit the same cache entry share a single future.
         """
-        parsed = parse_title(path.stem, self._config.media_type)
+        parsed = parse_title(path.stem, self._config.media_type or "")
         if parsed.tvdb_id:
             return ("tv", "tvdb", parsed.tvdb_id)
         if parsed.tmdb_id:
@@ -367,7 +368,8 @@ class Walk:
                 symlinks=self._config.symlinks,
                 ignore=self._config.ignore,
                 check_config=self._config.timestamps_check_config,
-                program_config=self._config,
+                # GrovestampsConfig wants a Mapping; convert the dataclass.
+                program_config=asdict(self._config),
                 program_config_keys=TIMESTAMPS_CONFIG_KEYS,
             )
             self._timestamps = Grovestamps(grove_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ classifiers = [
   "Topic :: Multimedia :: Video :: Conversion",
 ]
 dependencies = [
-  "confuse~=2.1.0,<2.2.0",
+  "confuse~=2.2.0",
   "loguru~=0.7",
   "platformdirs>=4.9.6",
   "pycountry~=26.2",

--- a/tests/test_mkv.py
+++ b/tests/test_mkv.py
@@ -10,7 +10,7 @@ from nudebomb.mkv import MKVFile
 from tests.util import SRC_PATH, TEST_FN, DiffTracksTest, mkv_tracks
 
 if TYPE_CHECKING:
-    from confuse import AttrDict
+    from nudebomb.config import NudebombSettings
 
 __all__ = ()
 
@@ -51,7 +51,7 @@ class TestMkv(DiffTracksTest):
         self.src_tracks: list = mkv_tracks(TEST_MKV)  #  pyright: ignore[reportUninitializedInstanceVariable]
         os.environ["NUDEBOMB_NUDEBOMB__LANGUAGES__0"] = "und"
         os.environ["NUDEBOMB_NUDEBOMB__LANGUAGES__1"] = "eng"
-        self._config: AttrDict = NudebombConfig().get_config()  #  pyright: ignore[reportUninitializedInstanceVariable]
+        self._config: NudebombSettings = NudebombConfig().get_config()  #  pyright: ignore[reportUninitializedInstanceVariable]
 
     def teardown_method(self) -> None:
         """Tear down method."""
@@ -87,7 +87,7 @@ class TestMkv(DiffTracksTest):
 
     def test_fail(self) -> None:
         """Test fail."""
-        self._config.languages = ["xxx"]
+        self._config.languages = frozenset({"xxx"})
         mkvfile = MKVFile(self._config, TEST_MKV)
         mkvfile.remove_tracks()
         out_tracks = mkv_tracks(TEST_MKV)

--- a/uv.lock
+++ b/uv.lock
@@ -315,14 +315,14 @@ wheels = [
 
 [[package]]
 name = "confuse"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/01/7d24e53986959b6148da5d0ffbce3e02e844110ac126bb42f46cad645ec9/confuse-2.1.0.tar.gz", hash = "sha256:abb9674a99c7a6efaef84e2fc84403ecd2dd304503073ff76ea18ed4176e218d", size = 22748, upload-time = "2025-10-27T10:22:01.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/a6/444c7376439851ce1d07932f88b707910d4605466d1c313621943c738112/confuse-2.2.0.tar.gz", hash = "sha256:35c1b53e81be125f441bee535130559c935917b26aeaa61289010cd1f55c2b9e", size = 52496, upload-time = "2026-01-28T10:40:16.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/6a/60e8d4a0e48559ff05aa7c9c65449c3a29c32ffe9f0690dc94b526c73c1f/confuse-2.1.0-py3-none-any.whl", hash = "sha256:502be1299aa6bf7c48f7719f56795720c073fb28550c0c7a37394366c9d30316", size = 25049, upload-time = "2025-10-27T10:22:00.08Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5d/a1333543a1b40fcbb08830330f6ea7bc7a3bda387a7a0c2bead534f5c01f/confuse-2.2.0-py3-none-any.whl", hash = "sha256:470c6aa1a5008c8d740267f2ad574e3a715b6dd873c1e5f8778b7f7abb954722", size = 27904, upload-time = "2026-01-28T10:40:14.508Z" },
 ]
 
 [[package]]
@@ -1143,7 +1143,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "confuse", specifier = "~=2.1.0,<2.2.0" },
+    { name = "confuse", specifier = "~=2.2.0" },
     { name = "loguru", specifier = "~=0.7" },
     { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "pycountry", specifier = "~=26.2" },


### PR DESCRIPTION
## Summary

Bump \`confuse~=2.1.0,<2.2.0\` → \`confuse~=2.2.0\`. The bump alone produced 39 basedpyright errors because confuse 2.2.0 honestly types \`AttrDict\` as a generic \`dict[ConfigKeyT, V]\` with \`V = object\` default, so every downstream \`cfg.field\` access resolves to \`object\` instead of the concrete runtime type. Background and recommendation: see \`tasks/confuse-2.2.0-report.md\`.

This PR implements the recommended fix (option C1 from the report): stop passing \`AttrDict\` around as if it were a typed config. Build a typed dataclass once in \`get_config()\`; every downstream module consumes that.

## What changed

- **\`nudebomb/config.py\`** — new \`NudebombSettings\` (\`@dataclass(slots=True)\`) with one field per \`TEMPLATE\` entry. Fields use concrete types: \`tuple[str, ...]\` for ordered sequences (\`paths\`, \`ignore\`), \`frozenset[str]\` for fields consumed with set algebra (\`languages\`, \`sub_languages\`), and \`float | None\` for \`after\` (which \`_set_after\` converts to a timestamp). New \`_NudebombSchema\` TypedDict serves as a single-cast target so the AttrDict→dataclass conversion type-checks without per-field casts. Not frozen — \`Walk.strip_path\` legitimately deepcopies and overrides \`languages\` per-file from a discovered langfile.

- **\`nudebomb/lang.py\`** (new) — \`lang_to_alpha3\` extracted from \`langfiles.py\` so both \`config\` and \`langfiles\` can depend on it without an import cycle (\`langfiles\` now type-checks against \`NudebombSettings\`, which used to import \`lang_to_alpha3\` from \`langfiles\`). \`langfiles\` re-exports the name for back-compat.

- **\`nudebomb/walk.py\`**, **\`mkv.py\`**, **\`langfiles.py\`**, **\`lookup/tmdb.py\`**, **\`lookup/tvdb.py\`** — every \`AttrDict\` annotation renamed to \`NudebombSettings\`. \`from confuse import AttrDict\` (under \`TYPE_CHECKING:\`) becomes \`from nudebomb.config import NudebombSettings\` (still under \`TYPE_CHECKING:\`).

- **Narrowing at boundaries**:
  - \`walk.py\`: \`parse_title(path.stem, self._config.media_type or \"\")\` for the new \`str | None\` field.
  - \`walk.py\`: \`program_config=asdict(self._config)\` for \`GrovestampsConfig\` which wants \`Mapping[str, Any]\`.
  - \`lookup/tmdb.py\`: \`self._media_type: str = config.media_type or \"\"\`.
  - \`lookup/tvdb.py\`: explicit guard at construction so the \`str | None\` API key narrows to \`str\` for \`tvdb_v4_official.TVDB(...)\`. Walk only constructs TVDBLookup when the key is truthy, so the runtime path never trips this.

- **Dead-code cleanup in \`config.py\`**: removed \`ad.paths = sorted(...)\` — it set a field on the discarded outer AttrDict that no consumer ever read. Surfaced separately in \`tasks/confuse-2.2.0-report.md\`.

## Test plan

- [x] \`make lint\` (basedpyright) — 0 errors, 0 warnings (was 39 errors)
- [x] \`make ty\` — all checks passed
- [x] \`make complexity\` — complexipy clean, no radon rank-C+ items
- [x] \`make test\` — 85/85 pass
- [x] Manual smoke: \`uv run nudebomb -d -t -l eng,und <path>\` renders the summary table correctly with \`Skipped (timestamp)\` and \`Not remuxed (dry run)\` rows.

## Reference for sibling projects

This change pattern is captured in \`tasks/proto-plan-confuse-2.2.0-migration.md\` for applying the same fix to comicbox / picopt when their confuse pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)