### PR TITLE
Colorize argparse help via rich-argparse

### DIFF
--- a/nudebomb/cli.py
+++ b/nudebomb/cli.py
@@ -1,10 +1,10 @@
 """Command line interface for nudebomb."""
 
-from argparse import Action, ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from argparse import Action, ArgumentParser, Namespace
 from collections.abc import Sequence
-from typing import Any, Final
+from typing import Any, ClassVar, Final
 
-from rich.console import Console
+from rich_argparse import RawDescriptionRichHelpFormatter
 from typing_extensions import override
 
 from nudebomb.config import NudebombConfig
@@ -33,6 +33,29 @@ class CommaListAction(Action):
         setattr(namespace, self.dest, values)
 
 
+class NudebombHelpFormatter(RawDescriptionRichHelpFormatter):
+    """
+    Help formatter that colorizes example values, defaults, and option refs.
+
+    Inherits the parent's ``--option`` highlighting (so options mentioned
+    in help strings render in the same color as in the option list) and
+    adds highlights for example values shown after ``e.g.`` or in single
+    quotes, and for ``Default: <value>`` callouts.
+    """
+
+    styles: ClassVar[dict[str, Any]] = {
+        **RawDescriptionRichHelpFormatter.styles,
+        "argparse.example": "green",
+        "argparse.default": "italic yellow",
+    }
+    highlights: ClassVar[list[str]] = [
+        *RawDescriptionRichHelpFormatter.highlights,
+        r"(?P<example>'[^']+')",
+        r"(?<=\be\.g\.\s)(?P<example>[\w,]+)",
+        r"\bDefault:\s+(?P<default>[\w-]+)",
+    ]
+
+
 # Order + label for each mark in the help epilogue legend. The char and
 # style are pulled from the centralized MARKS table so the legend can
 # never drift from what the bar actually renders.
@@ -53,13 +76,11 @@ CHAR_KEY_LABELS: Final[tuple[tuple[str, str], ...]] = (
 
 def get_progress_char_key() -> str:
     """Create the progress char legend for the help epilogue."""
-    console = Console(record=True, force_terminal=True, no_color=False)
-    console.begin_capture()
-    console.print("[bold]Progress char key:[/bold]")
+    lines = ["[bold]Progress char key:[/bold]"]
     for kind, label in CHAR_KEY_LABELS:
         mark = MARKS[kind]
-        console.print(f"\t[{mark.style}]{mark.char}[/{mark.style}]  {label}")
-    return console.end_capture()
+        lines.append(f"\t[{mark.style}]{mark.char}[/{mark.style}]  {label}")
+    return "\n".join(lines)
 
 
 def get_arguments(
@@ -71,7 +92,7 @@ def get_arguments(
     parser = ArgumentParser(
         description=description,
         epilog=epilog,
-        formatter_class=RawDescriptionHelpFormatter,
+        formatter_class=NudebombHelpFormatter,
     )
     parser.add_argument(
         "-d",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pycountry~=26.2",
   "python-dateutil~=2.8",
   "rich~=15.0",
+  "rich-argparse~=1.8",
   "ruamel-yaml>=0.18,<1.0",
   "tmdbsimple~=2.9",
   "treestamps~=4.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1094,6 +1094,7 @@ dependencies = [
     { name = "pycountry" },
     { name = "python-dateutil" },
     { name = "rich" },
+    { name = "rich-argparse" },
     { name = "ruamel-yaml" },
     { name = "tmdbsimple" },
     { name = "treestamps" },
@@ -1150,6 +1151,7 @@ requires-dist = [
     { name = "pycountry", specifier = "~=26.2" },
     { name = "python-dateutil", specifier = "~=2.8" },
     { name = "rich", specifier = "~=15.0" },
+    { name = "rich-argparse", specifier = "~=1.8" },
     { name = "ruamel-yaml", specifier = ">=0.18,<1.0" },
     { name = "tmdbsimple", specifier = "~=2.9" },
     { name = "treestamps", specifier = "~=4.0.2" },
@@ -1628,6 +1630,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-argparse"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/e5/1064c43203a357d668cd42435f7a15fe6af51512d85b2104fecb937aa861/rich_argparse-1.8.0.tar.gz", hash = "sha256:679df3d832fa94ad6e4bdb07ded088cd7ea2dddc58ae9b2b46346a40b06cbc0c", size = 38940, upload-time = "2026-05-01T15:18:43.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/35/1cceccc5fcb50fa2ed53e2aa278cd032f3902682a73e763fb1ac3be8e6fa/rich_argparse-1.8.0-py3-none-any.whl", hash = "sha256:d2a3ce7854654e2253c578763ab0a32f05016f23a55fadba7b9a91b6c0e92142", size = 25616, upload-time = "2026-05-01T15:18:42.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Switch the `nudebomb --help` formatter from `RawDescriptionHelpFormatter` to a small `NudebombHelpFormatter(RawDescriptionRichHelpFormatter)` subclass so the help output is colorized end-to-end.

## What changed

- **Option references** in help strings (e.g. *"Supersedes `--languages`"*) inherit the parent's default highlight and render in the same cyan as the actual option flags — no extra config needed.
- **Example values** get a new `argparse.example` style (green) plus two highlight regexes:
  - `'(?P<example>'[^']+')'` — single-quoted values like `'movie'`, `'tv'`, `'eng'`, `'en'`, `'und'`.
  - `(?<=\be\.g\.\s)(?P<example>[\w,]+)` — bare tokens after `e.g.`, like `eng,fra`.
- **Defaults** get an `argparse.default` style (italic yellow) and a highlight for `Default: <value>` callouts (catches `Default: 30` in `--cache-expiry-days`).
- **Progress char key (epilog)**: dropped the `Console.export()` ANSI capture in `get_progress_char_key()`; the epilog now returns plain Rich markup that flows through rich-argparse's `text_markup=True`, so the dot-color key is rendered by rich-argparse itself, driven by the centralized `MARKS` style strings.
- Adds `rich-argparse~=1.8` to runtime dependencies.

## Test plan

- [x] `make fix` — clean
- [x] `make lint` — clean
- [x] `make ty` — clean
- [x] `uv run pytest` — 85/85 pass
- [x] `radon cc --min C` / `complexipy` — no warnings
- [x] `nudebomb --help` rendered manually; verified options/examples/defaults all colorize and the legend shows each mark in its actual style

🤖 Generated with [Claude Code](https://claude.com/claude-code)